### PR TITLE
usb: fix libusb-1.0-0 package name

### DIFF
--- a/.devcontainer/jlink/install.sh
+++ b/.devcontainer/jlink/install.sh
@@ -5,7 +5,7 @@ apt update
 apt install -y \
     apt-transport-https \
     ca-certificates \
-    libusb-1.0 \
+    libusb-1.0-0 \
     libx11-xcb1 \
     libxcb-icccm4 \
     libxcb-image0 \


### PR DESCRIPTION
- This PR fixes the missing `libusb-1.0-0` package for userns access to the USB bus. 