### PR TITLE
fix: supress warning message about unused file during CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,8 @@ target_link_options(${PROJECT_NAME} PRIVATE
 
 # Generate additional outputs
 iar_elftool(${PROJECT_NAME})
+
+# Touch `build/DartConfiguration.tcl` (not used)
+# for supressing CMake Tools warning about 
+# missing file during during CTest
+file(TOUCH ${CMAKE_BINARY_DIR}/DartConfiguration.tcl)


### PR DESCRIPTION
- This PR fixes a warning message during CTest about a missing file which is not used for these tests (DartConfiguration.xcl)