### PR TITLE
Use CMAKE_C_EXTENSIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,15 @@ project(light-effects)
 enable_language(ASM)
 enable_testing()
 
+# Enable IAR Compiler extensions (-e)
+set(CMAKE_C_EXTENSIONS ON)
+
 # Add the executable target
 add_executable(${PROJECT_NAME})
 
 # Set the target's compiler options
 target_compile_options(${PROJECT_NAME} PRIVATE
-  $<$<COMPILE_LANGUAGE:C,CXX>:--dlib_config full --no_wrap_diagnostics -e>
+  $<$<COMPILE_LANGUAGE:C,CXX>:--dlib_config=full --no_wrap_diagnostics>
   $<$<COMPILE_LANGUAGE:ASM>:-s+>
   --cpu=cortex-m4
   --fpu=vfpv4_sp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,7 +40,7 @@ target_sources(linear_search_test PRIVATE
 set_target_properties(
   util
   PROPERTIES
-    COMPILE_OPTIONS "--cpu=cortex-m4;--dlib_config=full;-e;--no_wrap_diagnostics"
+    COMPILE_OPTIONS "--cpu=cortex-m4;--dlib_config=full;--no_wrap_diagnostics"
 )
 # Properties: unit testing
 set_target_properties(
@@ -50,7 +50,7 @@ set_target_properties(
   linear_search_test
   hello_test
   PROPERTIES
-    COMPILE_OPTIONS "--cpu=cortex-m4;--dlib_config=full;-e;--no_wrap_diagnostics"
+    COMPILE_OPTIONS "--cpu=cortex-m4;--dlib_config=full;--no_wrap_diagnostics"
     LINK_LIBRARIES util
     LINK_OPTIONS "--cpu=cortex-m4;--semihosting;--redirect=_Printf=_PrintfFullNoMb"
 )


### PR DESCRIPTION
This PR changes the way the project configures the compiler's IAR extensions (`-e`) option.